### PR TITLE
issue-cannot-use-working-directory-with-non-ascii-characters

### DIFF
--- a/repository/BaselineOfOSSubprocess.package/BaselineOfOSSubprocess.class/instance/baseline..st
+++ b/repository/BaselineOfOSSubprocess.package/BaselineOfOSSubprocess.class/instance/baseline..st
@@ -8,9 +8,15 @@ baseline: spec
 				
 			spec
 				package: 'OSSubprocess' with: [ spec requires: 'FFICHeaderExtractor' ];
-				package: 'OSSubprocess-Tests-Unit' with: [ spec requires: 'OSSubprocess' ];
+				package: 'OSSubprocess-Tests-Unit' with: [ spec requires: #('OSSubprocess' 'Unicode') ];
 				package: 'OSSubprocess-Tests-Stress' with: [ spec requires: 'OSSubprocess-Tests-Unit' ].
 			
 			spec baseline: 'FFICHeaderExtractor' with: [
-    			spec repository: 'github://marianopeck/FFICHeaderExtractor:master/repository' ]
+    			spec repository: 'github://marianopeck/FFICHeaderExtractor:master/repository' ].
+		
+			spec project: 'Unicode' with: [
+				spec
+					className: #ConfigurationOfUnicode;
+					versionString: #'stable';
+					repository: 'http://smalltalkhub.com/mc/Pharo/Unicode/main/' ].
 		]

--- a/repository/OSSubprocess-Tests-Unit.package/OSSVMProcessTest.class/instance/testChangeDirWithNonAsciiCharacters.st
+++ b/repository/OSSubprocess-Tests-Unit.package/OSSVMProcessTest.class/instance/testChangeDirWithNonAsciiCharacters.st
@@ -1,0 +1,16 @@
+tests
+testChangeDirWithNonAsciiCharacters
+	| oldDir newDir duringSystemCwd | 
+	oldDir := self systemAccessor getcwd.
+	newDir := FileLocator temp / 'strangË foldér namê'.
+	newDir ensureCreateDirectory.
+
+	OSSVMProcess vmProcess
+		lockCwdWithValue: newDir fullName 
+		during: [ duringSystemCwd := self systemAccessor getcwd ].
+	duringSystemCwd := UnicodeNormalizer new toNFC: duringSystemCwd asByteArray utf8Decoded.
+
+	"Grrr in latest OSX /tmp is mapped to /private/tmp..."
+	self assert: ((duringSystemCwd = newDir fullName) or: [ duringSystemCwd = ('/private' , newDir fullName) ]).
+	self assert: self systemAccessor getcwd equals: oldDir.
+	newDir ensureDelete.

--- a/repository/OSSubprocess.package/OSSUnixSubprocess.class/instance/loginShellCommand..st
+++ b/repository/OSSubprocess.package/OSSUnixSubprocess.class/instance/loginShellCommand..st
@@ -1,0 +1,6 @@
+shell
+loginShellCommand: aShellCommandString
+	"This is a simple facility method for the cases when the user wants to use a login shell as the program.
+	See comments of shellCommand: for more information."
+	command := self shellCommand.
+	arguments := Array with: '-l' with: '-c' with: aShellCommandString. 

--- a/repository/OSSubprocess.package/OSSUnixSubprocess.class/instance/shellCommand..st
+++ b/repository/OSSubprocess.package/OSSUnixSubprocess.class/instance/shellCommand..st
@@ -5,5 +5,5 @@ shellCommand: aShellCommandString
 	rather than having to do set the command sh, send the '-c' argument, etc etc etc.
 	We first try to use the SHELL defined in the OS by getting the env variable $SHELL. 
 	If not found, then we fallback to /bin/sh"
-	command := Smalltalk platform environment at: 'SHELL' ifAbsent: ['/bin/sh'].
+	command := self shellCommand.
 	arguments := Array with: '-c' with: aShellCommandString. 

--- a/repository/OSSubprocess.package/OSSUnixSubprocess.class/instance/shellCommand.st
+++ b/repository/OSSubprocess.package/OSSUnixSubprocess.class/instance/shellCommand.st
@@ -1,0 +1,5 @@
+shell
+shellCommand
+	"We first try to use the SHELL defined in the OS by getting the env variable $SHELL. 
+	If not found, then we fallback to /bin/sh"
+	^ Smalltalk platform environment at: 'SHELL' ifAbsent: ['/bin/sh']

--- a/repository/OSSubprocess.package/OSSUnixSystemAccessor.class/instance/primitiveGetcwd.size..st
+++ b/repository/OSSubprocess.package/OSSUnixSystemAccessor.class/instance/primitiveGetcwd.size..st
@@ -1,5 +1,5 @@
 cwd - primitives
 primitiveGetcwd: buffer size: size
 	
-	^ self ffiCall: #( char * getcwd(char *buffer, int size) )
+	^ self ffiCall: #( String getcwd(char *buffer, int size) )
 	

--- a/repository/OSSubprocess.package/OSSVMProcess.class/instance/lockCwdWithValue.during..st
+++ b/repository/OSSubprocess.package/OSSVMProcess.class/instance/lockCwdWithValue.during..st
@@ -26,7 +26,7 @@ lockCwdWithValue: cwdNewValue during: aBlock
 		| oldCwd |
 		oldCwd := self systemAccessor getcwd.
 		[
-			self systemAccessor chdir: cwdNewValue.
+			self systemAccessor chdir: cwdNewValue utf8Encoded asString.
 			mutexForCwd critical: aBlock.
 		]
 		ensure: [ 


### PR DESCRIPTION
Allow to use working directory containing non-ascii characters.
Add a convenient method to run a login shell.