### PR TITLE
43-OSSubprocess-should-not-raise-an-error-at-startup-on-windows

### DIFF
--- a/repository/OSSubprocess.package/OSSVMProcess.class/class/initialize.st
+++ b/repository/OSSubprocess.package/OSSVMProcess.class/class/initialize.st
@@ -1,5 +1,7 @@
 initialize - release
 initialize
+	Smalltalk os isWindows ifTrue: [ ^ self ]. "Cannot be initialized nor used on Windows."
+	
 	self initializeVMProcessInstance. 
 	self flag: #removeIt.
 	"This IF will be eliminated soon...only here temporary"


### PR DESCRIPTION
do not initialize OSSVMProcess on Windows. Fixes #43