### PR TITLE
Baseline should be update to not depend anymore on smalltalk/Unicode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,4 @@ before_script:
   - mkdir -p $SMALLTALK_CI_BUILD/UCD && cp UCD/* $SMALLTALK_CI_BUILD/UCD/
 
 script:
-  - travis_wait 120 sleep infinity &
-  - $SMALLTALK_CI_HOME/run.sh ${CI_FILE}
+  - travis_wait 60 $SMALLTALK_CI_HOME/run.sh ${CI_FILE}

--- a/repository/BaselineOfOSSubprocess.package/BaselineOfOSSubprocess.class/instance/baseline..st
+++ b/repository/BaselineOfOSSubprocess.package/BaselineOfOSSubprocess.class/instance/baseline..st
@@ -8,16 +8,13 @@ baseline: spec
 				package: 'OSSubprocess' with: [ spec requires: 'FFICHeaderExtractor' ];
 				package: 'OSSubprocess-Tests-Unit' with: [ spec requires: #('OSSubprocess' 'Unicode') ];
 				package: 'OSSubprocess-Tests-Stress' with: [ spec requires: 'OSSubprocess-Tests-Unit' ].
-			
+
 			spec baseline: 'FFICHeaderExtractor' with: [
-    			spec repository: 'github://marianopeck/FFICHeaderExtractor:master/repository' ].
-		
-			spec project: 'Unicode' with: [
-				spec
-					className: #ConfigurationOfUnicode;
-					versionString: #'stable';
-					repository: 'http://smalltalkhub.com/mc/Pharo/Unicode/main/' ].
-			
+    			spec repository: 'github://marianopeck/FFICHeaderExtractor/repository' ].
+
+			spec baseline: 'Unicode' with: [
+				spec repository: 'github://pharo-contributions/pharo-unicode/repository' ].
+
 			spec
 				group: 'Core' with: #( 'OSSubprocess' );
 				group: 'Tests' with: #( 'OSSubprocess-Tests-Unit' 'OSSubprocess-Tests-Stress' ).

--- a/repository/OSSubprocess-Tests-Unit.package/OSSFileBasedUnixSubprocessTest.class/instance/getStreamsInfoForRunningTest.st
+++ b/repository/OSSubprocess-Tests-Unit.package/OSSFileBasedUnixSubprocessTest.class/instance/getStreamsInfoForRunningTest.st
@@ -1,12 +1,11 @@
 helpers
 getStreamsInfoForRunningTest
-	"We obtain the open tmp files before the open files because apparently getting the entries of /tmp using
+	"We obtain the open tmp files before the open files because in Pharo 7 and ealier getting the entries of /tmp using
+
 	    '/tmp' asFileReference entries
-	
-	opens a file descriptor and lets the FD open. Thus #numberOfOpenFiles, using lsof, detects /tmp as an open file and makes the test fail.
-	
-	This happens only in travis under Ubuntu.
-	"
+
+	leaves the /tmp file descriptor open. Thus #numberOfOpenFiles, using lsof, detects /tmp as an open file and makes the test fail.
+	Fixed in Pharo 8."
 	| openTmpFiles |
 	openTmpFiles := self numberOfExistingTempStreamFiles.
 	^ Array with: self numberOfOpenFiles with: openTmpFiles

--- a/repository/OSSubprocess-Tests-Unit.package/OSSUnixSubprocessTest.class/instance/numberOfOpenFiles.st
+++ b/repository/OSSubprocess-Tests-Unit.package/OSSUnixSubprocessTest.class/instance/numberOfOpenFiles.st
@@ -1,20 +1,16 @@
 helpers
 numberOfOpenFiles
-	"This is estimation number. Not to be used for real code. IT's basically 
-	to check the number of opened files (regular files, directories, pipes) at the beginning of a  test and at the end, to validate we are not leaving behind opened files. 
-	This should work in most Unix-like and Linux
-	"
+	"This is estimation number. Not to be used for real code. It's basically to check the number of opened FIFO files at the beginning of a test and at the end, to validate we are not leaving behind opened files.
+	This should work in most Unix-like and Linux systems.
+	Only FIFO files are checked as we can't control other threads, and it is redirecting stdio that is happening in the tests."
 	| tmpFileName openFiles |
 	tmpFileName := (FileSystem workingDirectory / 'openFilesByPharoVM-' , UUID new printString) fullName.
 	tmpFileName asFileReference ensureDelete.
 	self systemAccessor system: ('lsof -p ', OSSVMProcess vmProcess pid printString, ' > "', tmpFileName, '" 2>&1').
 	openFiles := tmpFileName asFileReference readStreamDo: [ :str | | lines |
-		"We avoid the first header line" 
-		lines := str contents lines allButFirst sorted.
-		
-		"We then ignore all file properties except for the file name"
-		lines collect: [ :each | each substrings last ]
+		lines := str contents lines.
+		"Count only pipes"
+		lines select: [ :each | each includesSubstring: 'FIFO' ]
 	].
 	tmpFileName asFileReference ensureDelete.
-	^ openFiles
-	
+	^ openFiles size

--- a/repository/OSSubprocess-Tests-Unit.package/OSSUnixSubprocessTest.class/instance/testReadingFromStdoutAfterCommandFinishesDoesNotBlocksVM.st
+++ b/repository/OSSubprocess-Tests-Unit.package/OSSUnixSubprocessTest.class/instance/testReadingFromStdoutAfterCommandFinishesDoesNotBlocksVM.st
@@ -12,7 +12,7 @@ testReadingFromStdoutAfterCommandFinishesDoesNotBlocksVM
 	streamsInfo := self getStreamsInfoForRunningTest.
 	command := self newCommand
 					command: '/bin/sleep';
-					arguments: (Array with: '15');
+					arguments: (Array with: '1');
 					redirectStdout;
 					runAndWait.
 					


### PR DESCRIPTION
Load Unicode from github repository (was SmalltalkHub).

Fixes: https://github.com/pharo-contributions/OSSubprocess/issues/55