### PR TITLE
Better support for moving images between Windows and Linux (fixes #78)

### DIFF
--- a/repository/OSSubprocess/OSSUnixSubprocess.class.st
+++ b/repository/OSSubprocess/OSSUnixSubprocess.class.st
@@ -65,8 +65,18 @@ Class {
 	#pools : [
 		'LibCSignalSharedPool'
 	],
-	#category : 'OSSubprocess'
+	#category : #OSSubprocess
 }
+
+{ #category : #'temp files' }
+OSSUnixSubprocess class >> createTempFilename [
+	"Read comment of createTempFileToBeUsedAsReadStreamOn:.
+	
+	This answers just ONE WAY of defining a temp filename"
+	
+	^ self name , '-p', OSSVMProcess vmProcess pid asString, '-', UUID new printString, '.deleteme'
+	
+]
 
 { #category : #'temp files' }
 OSSUnixSubprocess class >> createTempFileToBeUsedAsReadStreamOn: aDirectoryPath [
@@ -88,16 +98,6 @@ OSSUnixSubprocess class >> createTempFileToBeUsedAsReadStreamOn: aDirectoryPath 
 OSSUnixSubprocess class >> createTempFileToBeUsedAsWriteStreamOn: aDirectoryPath [
 	"See comment of #createTempFileToBeUsedAsReadStreamOn:."
 	^  OldStandardFileStream forceNewFileNamed: (aDirectoryPath asFileReference / self createTempFilename) fullName
-]
-
-{ #category : #'temp files' }
-OSSUnixSubprocess class >> createTempFilename [
-	"Read comment of createTempFileToBeUsedAsReadStreamOn:.
-	
-	This answers just ONE WAY of defining a temp filename"
-	
-	^ self name , '-p', OSSVMProcess vmProcess pid asString, '-', UUID new printString, '.deleteme'
-	
 ]
 
 { #category : #'env building' }
@@ -262,7 +262,7 @@ OSSUnixSubprocess >> collectArgumentPointersInto: aPointer [
 		pointer := ExternalAddress allocate: string size + 1.
 		self registerPointer: pointer.
 		LibC memCopy: string to: pointer size: string size.
-		pointer nbUInt8AtOffset: string size put: 0. "string terminating null char"
+		pointer uint8AtOffset: string size put: 0. "string terminating null char"
 		aPointer platformUnsignedLongAt: ((index - 1) * self systemAccessor sizeOfPointer) + 1 put: pointer value ].
 
 	aPointer platformUnsignedLongAt: ((self argVArguments size - 1) * self systemAccessor sizeOfPointer) + 1 put: 0.
@@ -279,7 +279,7 @@ OSSUnixSubprocess >> collectEnvVariablesPointersInto: aPointer [
 		pointer := ExternalAddress allocate: string size + 1.
 		self registerPointer: pointer.
 		LibC memCopy: string to: pointer size: string size.
-		pointer nbUInt8AtOffset: string size put: 0. "string terminating null char"
+		pointer uint8AtOffset: string size put: 0. "string terminating null char"
 		aPointer platformUnsignedLongAt: ((index - 1) * self systemAccessor sizeOfPointer) + 1 put: pointer value
 	].
 	"The array of pointers also needs to finish with a NULL"

--- a/repository/OSSubprocess/OSSVMProcess.class.st
+++ b/repository/OSSubprocess/OSSVMProcess.class.st
@@ -30,33 +30,24 @@ Class {
 		'LibCErrnoSharedPool',
 		'LibCWaitSharedPool'
 	],
-	#category : 'OSSubprocess'
+	#category : #OSSubprocess
 }
 
 { #category : #'initialize - release' }
 OSSVMProcess class >> initialize [
-	Smalltalk os isWindows ifTrue: [ ^ self ]. "Cannot be initialized nor used on Windows."
-	
-	self initializeVMProcessInstance. 
-	self flag: #removeIt.
-	"This IF will be eliminated soon...only here temporary"
-	(SystemVersion current highestUpdate >= 50558)
-		ifTrue: [ 
-			SessionManager default registerToolClassNamed: self name
-			 ]
-		ifFalse: [ 
-			Smalltalk addToStartUpList: OSSVMProcess.
-			Smalltalk addToShutDownList: OSSVMProcess.
- 		]
-	
+
+	self initializeVMProcessInstance.
+	SessionManager default registerToolClassNamed: self name
 ]
 
 { #category : #'initialize - release' }
 OSSVMProcess class >> initializeVMProcessInstance [
-	VMProcess isNil 
-		ifTrue: [ VMProcess := self basicNew. ]
-		ifFalse: [ VMProcess finalizePreviousSession ].
-	VMProcess initialize.
+
+	VMProcess ifNotNil: [
+		VMProcess finalizePreviousSession.
+		VMProcess := nil ].
+	Smalltalk os isWindows ifFalse: [
+		VMProcess := self basicNew initialize ]
 ]
 
 { #category : #'instance creation' }
@@ -73,18 +64,8 @@ OSSVMProcess class >> shutDown: quitting [
 
 { #category : #'system startup' }
 OSSVMProcess class >> startUp: resuming [
-	
-	resuming ifTrue: [ 
-		"To understand why the #stopWaiting, first read the comment of 
-		OSSVMProcess shutDown:
-		It could happen that when the shutDown happened, the child process
-		was in the wait of #waitForExitPollingEvery:doing:. Therefore, until the
-		next cycle of the loop it won't do the queryExitStatus. So we may still 
-		have this problem in image startup. So just in case we run it too in the startup code.
-		 "
-		self vmProcess activeChildren do: [ :each | each stopWaiting ].
-		self initializeVMProcessInstance.
-		]
+
+	resuming ifTrue: [ self initializeVMProcessInstance ]
 ]
 
 { #category : #'OS Process' }
@@ -187,15 +168,19 @@ OSSVMProcess >> finalizePreviousSession [
 	"This method is likely called at image startup and it's job is to finalize
 	stuff related to the previous run and let everything clean so that 
 	the unique instance vmProcess of OSSVMProcess can be initialized correctly at startup. "
-	childWatcher ifNotNil: [ 
+
+	childWatcher ifNotNil: [
 		childWatcher isTerminated ifFalse: [ childWatcher terminate ].
-		childWatcher := nil.
-	].
+		childWatcher := nil ].
 	sigChldSemaphore ifNotNil: [
 		self systemAccessor restoreSigChld.
-		sigChldSemaphore := nil
-	]
-
+		sigChldSemaphore := nil ].
+	"To understand why the #stopWaiting, first read the comment of #shutDown:.
+	It could happen that when the shutDown happened, the child process was in
+	the wait of #waitForExitPollingEvery:doing:. Therefore, until the next cycle
+	of the loop it won't do the queryExitStatus. So we may still 	have this
+	problem in image startup. So just in case we run it too in the startup code."
+	self activeChildren do: [ :each | each stopWaiting ]
 ]
 
 { #category : #'initialize - release' }


### PR DESCRIPTION
Register OSSVMProcess to startup lists when installing on Windows so it will have the opportunity to initialize if the image is started on Linux. Discard the old `VMProcess` after finalizing previous session, and only make a new one on not-Windows, so we don't leave obsolete information lying around.

Fixes #78.