### PR TITLE
nil-check VMProcess when shutting down, will be nil on Windows

### DIFF
--- a/repository/OSSubprocess/OSSVMProcess.class.st
+++ b/repository/OSSubprocess/OSSVMProcess.class.st
@@ -59,7 +59,7 @@ OSSVMProcess class >> new [
 
 { #category : #'system startup' }
 OSSVMProcess class >> shutDown: quitting [
-	self vmProcess shutDown: quitting
+	self vmProcess ifNotNil: [:a | a shutDown: quitting]
 ]
 
 { #category : #'system startup' }


### PR DESCRIPTION
Oops, missed this—I think because I didn't save and restart my image to actually run the new startup code _in Windows_, then save/exit (which is when this change is needed), just checked that it made things work in Linux.