### PR TITLE
Fix tests and example code to run under Pharo 14

### DIFF
--- a/repository/OSSubprocess-Tests-Unit/OSSAbstractUnixSubprocessTest.class.st
+++ b/repository/OSSubprocess-Tests-Unit/OSSAbstractUnixSubprocessTest.class.st
@@ -1,21 +1,22 @@
 Class {
-	#name : #OSSAbstractUnixSubprocessTest,
-	#superclass : #TestCase,
-	#category : 'OSSubprocess-Tests-Unit'
+	#name : 'OSSAbstractUnixSubprocessTest',
+	#superclass : 'TestCase',
+	#category : 'OSSubprocess-Tests-Unit',
+	#package : 'OSSubprocess-Tests-Unit'
 }
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 OSSAbstractUnixSubprocessTest >> commandClass [
 	^ OSSUnixSubprocess 
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 OSSAbstractUnixSubprocessTest >> newCommand [
 	
 	^ self commandClass new
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 OSSAbstractUnixSubprocessTest >> systemAccessor [
 	^ OSSVMProcess vmProcess systemAccessor
 ]

--- a/repository/OSSubprocess-Tests-Unit/OSSFileBasedUnixSubprocessTest.class.st
+++ b/repository/OSSubprocess-Tests-Unit/OSSFileBasedUnixSubprocessTest.class.st
@@ -1,10 +1,11 @@
 Class {
-	#name : #OSSFileBasedUnixSubprocessTest,
-	#superclass : #OSSUnixSubprocessTest,
-	#category : 'OSSubprocess-Tests-Unit'
+	#name : 'OSSFileBasedUnixSubprocessTest',
+	#superclass : 'OSSUnixSubprocessTest',
+	#category : 'OSSubprocess-Tests-Unit',
+	#package : 'OSSubprocess-Tests-Unit'
 }
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 OSSFileBasedUnixSubprocessTest >> assertStreamsInfoWithPrevious: beforeArray [
 	| afterArray |
 	afterArray := self getStreamsInfoForRunningTest.
@@ -12,7 +13,7 @@ OSSFileBasedUnixSubprocessTest >> assertStreamsInfoWithPrevious: beforeArray [
 	self assert: beforeArray second equals: afterArray second.
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 OSSFileBasedUnixSubprocessTest >> getStreamsInfoForRunningTest [
 	"We obtain the open tmp files before the open files because in Pharo 7 and ealier getting the entries of /tmp using
 
@@ -25,7 +26,7 @@ OSSFileBasedUnixSubprocessTest >> getStreamsInfoForRunningTest [
 	^ Array with: self numberOfOpenFiles with: openTmpFiles
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 OSSFileBasedUnixSubprocessTest >> newCommand [
 	| command |
 	command := self commandClass new.
@@ -35,7 +36,7 @@ OSSFileBasedUnixSubprocessTest >> newCommand [
 	
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 OSSFileBasedUnixSubprocessTest >> numberOfExistingTempStreamFiles [
 	"This answers the number of files that were created for mapping standard files.
 	Note that in OSSUnixSubprocessTest >> newCommand we define that temp files must be created in /tmp
@@ -46,7 +47,7 @@ OSSFileBasedUnixSubprocessTest >> numberOfExistingTempStreamFiles [
 		(each name beginsWith: 'OSSUnixSubprocess-p')  and: [ each name endsWith: '.deleteme' ]  ]) size	
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 OSSFileBasedUnixSubprocessTest >> testBasicCommandWriteToStdin [
 "testBasicCommandWriteToStdin  fails because of what the documentation says:
 	> **Important** We have found some problems when using regular files for the `stdin`. While we do not strictly forbid that, we recommend you do so only if you know very well what you are doing. Otherwise, use blocking pipes for `stdin` (default behavior).
@@ -55,7 +56,7 @@ OSSFileBasedUnixSubprocessTest >> testBasicCommandWriteToStdin [
 	
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 OSSFileBasedUnixSubprocessTest >> testReadingFromStdoutAfterCommandFinishesDoesNotBlocksVM [
 	
 	"testReadingFromStdoutAfterCommandFinishesDoesNotBlocksVM fails on Travis on OSX. It looks like if another test would have run while this one was sleeping and hence in #assertStreamsInfoWithPrevious: it fails because there are 2 new not-closed files...which I suspect that those are from another running test..."
@@ -65,7 +66,7 @@ OSSFileBasedUnixSubprocessTest >> testReadingFromStdoutAfterCommandFinishesDoesN
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 OSSFileBasedUnixSubprocessTest >> testReadingFromStdoutDoesNotBlocksVM [
 	| command | 
 	"With files, the reading from stdout does not lock the VM"
@@ -80,7 +81,7 @@ OSSFileBasedUnixSubprocessTest >> testReadingFromStdoutDoesNotBlocksVM [
 	command closeAndCleanStreams.
 ]
 
-{ #category : #'tests - signals' }
+{ #category : 'tests - signals' }
 OSSFileBasedUnixSubprocessTest >> testSigTerm [
 	"Same as super impl but special handling for #assertStreamsInfoWithPrevious:. Read comment at the bottom"
 	| process exited streamsInfo |

--- a/repository/OSSubprocess-Tests-Unit/OSSPipeBasedUnixSubprocessTest.class.st
+++ b/repository/OSSubprocess-Tests-Unit/OSSPipeBasedUnixSubprocessTest.class.st
@@ -1,10 +1,11 @@
 Class {
-	#name : #OSSPipeBasedUnixSubprocessTest,
-	#superclass : #OSSUnixSubprocessTest,
-	#category : 'OSSubprocess-Tests-Unit'
+	#name : 'OSSPipeBasedUnixSubprocessTest',
+	#superclass : 'OSSUnixSubprocessTest',
+	#category : 'OSSubprocess-Tests-Unit',
+	#package : 'OSSubprocess-Tests-Unit'
 }
 
-{ #category : #helper }
+{ #category : 'helper' }
 OSSPipeBasedUnixSubprocessTest >> newCommand [
 	
 	^ self commandClass new
@@ -16,7 +17,7 @@ OSSPipeBasedUnixSubprocessTest >> newCommand [
 	
 ]
 
-{ #category : #'tests - streams' }
+{ #category : 'tests - streams' }
 OSSPipeBasedUnixSubprocessTest >> testCommandTryToWriteToStdoutButHasNoReader [
 	| command errString  | 
 	command := self newCommand
@@ -36,7 +37,7 @@ OSSPipeBasedUnixSubprocessTest >> testCommandTryToWriteToStdoutButHasNoReader [
 	command closeAndCleanStreams.
 ]
 
-{ #category : #'tests - streams' }
+{ #category : 'tests - streams' }
 OSSPipeBasedUnixSubprocessTest >> testReadingFromStdoutBlocksVM [
 	| command customStream | 
 	customStream := self systemAccessor makeBlockingPipe.
@@ -51,7 +52,7 @@ OSSPipeBasedUnixSubprocessTest >> testReadingFromStdoutBlocksVM [
 	command closeAndCleanStreams.
 ]
 
-{ #category : #'tests - streams' }
+{ #category : 'tests - streams' }
 OSSPipeBasedUnixSubprocessTest >> testReadingFromStdoutDoesNotBlocksVM [
 	| command customStream | 
 	customStream := self systemAccessor makeNonBlockingPipe.

--- a/repository/OSSubprocess-Tests-Unit/OSSPipeTest.class.st
+++ b/repository/OSSubprocess-Tests-Unit/OSSPipeTest.class.st
@@ -1,22 +1,23 @@
 Class {
-	#name : #OSSPipeTest,
-	#superclass : #OSSAbstractUnixSubprocessTest,
-	#category : 'OSSubprocess-Tests-Unit'
+	#name : 'OSSPipeTest',
+	#superclass : 'OSSAbstractUnixSubprocessTest',
+	#category : 'OSSubprocess-Tests-Unit',
+	#package : 'OSSubprocess-Tests-Unit'
 }
 
-{ #category : #private }
+{ #category : 'private' }
 OSSPipeTest >> blockingPipe [
 	^ self systemAccessor makeBlockingPipe
 	
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 OSSPipeTest >> nonBlockingPipe [
 	^ self systemAccessor makeNonBlockingPipe
 	
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 OSSPipeTest >> readFromAndClose: aPipe writingTo: aStream [
 
 	| s |
@@ -29,7 +30,7 @@ OSSPipeTest >> readFromAndClose: aPipe writingTo: aStream [
 
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 OSSPipeTest >> testBasicWriteAndRead [
 	| pipe string readString |
 	string := 'this is a testing string'. 
@@ -39,7 +40,7 @@ OSSPipeTest >> testBasicWriteAndRead [
 	self assert: string equals: readString
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 OSSPipeTest >> testBlocking [
 
 	| pipe |
@@ -63,7 +64,7 @@ OSSPipeTest >> testBlocking [
 
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 OSSPipeTest >> testBlockingPeek [
 
 		| pipe |
@@ -84,7 +85,7 @@ OSSPipeTest >> testBlockingPeek [
 
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 OSSPipeTest >> testIsAtEndOfFile [
 
 	| pipe |
@@ -130,7 +131,7 @@ OSSPipeTest >> testIsAtEndOfFile [
 
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 OSSPipeTest >> testIsAtEndOfFile2 [
 
 	| pipe string |
@@ -148,7 +149,7 @@ OSSPipeTest >> testIsAtEndOfFile2 [
 
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 OSSPipeTest >> testNonBlocking [
 
 	| pipe writeStream string |
@@ -161,7 +162,7 @@ OSSPipeTest >> testNonBlocking [
 
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 OSSPipeTest >> testNonBlockingPeek [
 
 	| pipe |
@@ -181,7 +182,7 @@ OSSPipeTest >> testNonBlockingPeek [
 
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 OSSPipeTest >> testReadAfterClosedReadEnd [
 	| pipe writeStream readStream string |
 	string := 'this is a testing string'. 
@@ -195,7 +196,7 @@ OSSPipeTest >> testReadAfterClosedReadEnd [
 	
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 OSSPipeTest >> testWriteAfterClosedWriteEnd [
 	| pipe writeStream string |
 	string := 'this is a testing string'. 
@@ -205,7 +206,7 @@ OSSPipeTest >> testWriteAfterClosedWriteEnd [
 	
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 OSSPipeTest >> writeStuffOnThenClose: aPipe [
 
 	^ [(1 to: 10) do:

--- a/repository/OSSubprocess-Tests-Unit/OSSUnixSubprocessTest.class.st
+++ b/repository/OSSubprocess-Tests-Unit/OSSUnixSubprocessTest.class.st
@@ -1,10 +1,11 @@
 Class {
-	#name : #OSSUnixSubprocessTest,
-	#superclass : #OSSAbstractUnixSubprocessTest,
-	#category : 'OSSubprocess-Tests-Unit'
+	#name : 'OSSUnixSubprocessTest',
+	#superclass : 'OSSAbstractUnixSubprocessTest',
+	#category : 'OSSubprocess-Tests-Unit',
+	#package : 'OSSubprocess-Tests-Unit'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 OSSUnixSubprocessTest class >> isAbstract [
 	"Override to true if a TestCase subclass is Abstract and should not have
 	TestCase instances built from it"
@@ -13,17 +14,17 @@ OSSUnixSubprocessTest class >> isAbstract [
 			
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 OSSUnixSubprocessTest >> assertStreamsInfoWithPrevious: anObject [ 
 	self assert: self getStreamsInfoForRunningTest equals: anObject
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 OSSUnixSubprocessTest >> getStreamsInfoForRunningTest [
 	^ self numberOfOpenFiles 
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 OSSUnixSubprocessTest >> numberOfOpenFiles [
 	"This is estimation number. Not to be used for real code. It's basically to check the number of opened FIFO files at the beginning of a test and at the end, to validate we are not leaving behind opened files.
 	This should work in most Unix-like and Linux systems.
@@ -42,7 +43,7 @@ OSSUnixSubprocessTest >> numberOfOpenFiles [
 
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 OSSUnixSubprocessTest >> numberOfZombiesProcesses [
 	"This is estimation number. Not to be used for real code. IT's basically 
 	to check the number of zombies at the beginning of a  test and at the end, to validate we are not leaving behind new zombies. 
@@ -60,7 +61,7 @@ OSSUnixSubprocessTest >> numberOfZombiesProcesses [
 	
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 OSSUnixSubprocessTest >> ppidOf: childPid [
 	"Answers the parent pid (ppid) of the childPid
 	"
@@ -78,7 +79,7 @@ OSSUnixSubprocessTest >> ppidOf: childPid [
 	
 ]
 
-{ #category : #'tests - env' }
+{ #category : 'tests - env' }
 OSSUnixSubprocessTest >> testAddAllEnvVariablesFromParent [
 	| command | 
 	command := self newCommand
@@ -92,7 +93,7 @@ OSSUnixSubprocessTest >> testAddAllEnvVariablesFromParent [
 
 ]
 
-{ #category : #'tests - env' }
+{ #category : 'tests - env' }
 OSSUnixSubprocessTest >> testAddAllEnvVariablesFromParentWithoutOverride [
 	| command | 
 	"Here we assume that the parent process will have the $PATH defined."
@@ -108,7 +109,7 @@ OSSUnixSubprocessTest >> testAddAllEnvVariablesFromParentWithoutOverride [
 
 ]
 
-{ #category : #'tests - env' }
+{ #category : 'tests - env' }
 OSSUnixSubprocessTest >> testAddOnlyOneVariable [
 	| command | 
 	command := self newCommand
@@ -121,7 +122,7 @@ OSSUnixSubprocessTest >> testAddOnlyOneVariable [
 
 ]
 
-{ #category : #'tests - basic' }
+{ #category : 'tests - basic' }
 OSSUnixSubprocessTest >> testBasicCommand [
 	| command |
 	command := self newCommand 
@@ -130,7 +131,7 @@ OSSUnixSubprocessTest >> testBasicCommand [
 	
 ]
 
-{ #category : #'tests - streams' }
+{ #category : 'tests - streams' }
 OSSUnixSubprocessTest >> testBasicCommandReadFromStderr [
 	| streamsInfo |
 	streamsInfo := self getStreamsInfoForRunningTest.
@@ -148,7 +149,7 @@ OSSUnixSubprocessTest >> testBasicCommandReadFromStderr [
 	
 ]
 
-{ #category : #'tests - streams' }
+{ #category : 'tests - streams' }
 OSSUnixSubprocessTest >> testBasicCommandReadFromStdout [
 	| streamsInfo |
 	streamsInfo := self getStreamsInfoForRunningTest.
@@ -164,7 +165,7 @@ OSSUnixSubprocessTest >> testBasicCommandReadFromStdout [
 	
 ]
 
-{ #category : #'tests - basic' }
+{ #category : 'tests - basic' }
 OSSUnixSubprocessTest >> testBasicCommandWithArgument [
 	| command | 
 	
@@ -175,7 +176,7 @@ OSSUnixSubprocessTest >> testBasicCommandWithArgument [
 	command runAndWait
 ]
 
-{ #category : #'tests - basic' }
+{ #category : 'tests - basic' }
 OSSUnixSubprocessTest >> testBasicCommandWithNonAsciiArgument [
 	| command | 
 	
@@ -188,7 +189,7 @@ OSSUnixSubprocessTest >> testBasicCommandWithNonAsciiArgument [
 
 ]
 
-{ #category : #'tests - basic' }
+{ #category : 'tests - basic' }
 OSSUnixSubprocessTest >> testBasicCommandWithoutFullPath [
 
 	self newCommand
@@ -202,7 +203,7 @@ OSSUnixSubprocessTest >> testBasicCommandWithoutFullPath [
 
 ]
 
-{ #category : #'tests - streams' }
+{ #category : 'tests - streams' }
 OSSUnixSubprocessTest >> testBasicCommandWriteToStdin [
 	| command stdOutString string streamsInfo | 
 	streamsInfo := self getStreamsInfoForRunningTest.
@@ -227,7 +228,7 @@ OSSUnixSubprocessTest >> testBasicCommandWriteToStdin [
 
 ]
 
-{ #category : #'tests - streams' }
+{ #category : 'tests - streams' }
 OSSUnixSubprocessTest >> testBasicCommandWriteToStdin2 [
 	| command streamsInfo outString | 
 	streamsInfo := self getStreamsInfoForRunningTest.
@@ -254,7 +255,7 @@ OSSUnixSubprocessTest >> testBasicCommandWriteToStdin2 [
 
 ]
 
-{ #category : #'tests - shell' }
+{ #category : 'tests - shell' }
 OSSUnixSubprocessTest >> testBasicShellCommand [
 	| command | 
 	
@@ -265,7 +266,7 @@ OSSUnixSubprocessTest >> testBasicShellCommand [
 	
 ]
 
-{ #category : #'tests - shell' }
+{ #category : 'tests - shell' }
 OSSUnixSubprocessTest >> testBasicShellCommandWithNonAsciiCharacters [
 	
 	self withNonAsciiDirectoryDo: [ :dir |
@@ -279,7 +280,7 @@ OSSUnixSubprocessTest >> testBasicShellCommandWithNonAsciiCharacters [
 	]
 ]
 
-{ #category : #'tests - shell' }
+{ #category : 'tests - shell' }
 OSSUnixSubprocessTest >> testBasicShellCommandWithStdout [
 
 	self newCommand
@@ -292,7 +293,7 @@ OSSUnixSubprocessTest >> testBasicShellCommandWithStdout [
 
 ]
 
-{ #category : #'tests - child status' }
+{ #category : 'tests - child status' }
 OSSUnixSubprocessTest >> testCheckZombieStateAndTestChildWatcherWorking [
 	| command oldZombies | 
 	oldZombies := self numberOfZombiesProcesses.
@@ -312,7 +313,7 @@ OSSUnixSubprocessTest >> testCheckZombieStateAndTestChildWatcherWorking [
 	
 ]
 
-{ #category : #'tests - child status' }
+{ #category : 'tests - child status' }
 OSSUnixSubprocessTest >> testCheckZombieStateWithNonExistingCommang [
 	| command oldZombies | 
 	oldZombies := self numberOfZombiesProcesses.
@@ -333,7 +334,7 @@ OSSUnixSubprocessTest >> testCheckZombieStateWithNonExistingCommang [
 	
 ]
 
-{ #category : #'tests - child status' }
+{ #category : 'tests - child status' }
 OSSUnixSubprocessTest >> testCheckZombieStateWithOnExitApi [
 	| command oldZombies | 
 	oldZombies := self numberOfZombiesProcesses.
@@ -347,7 +348,7 @@ OSSUnixSubprocessTest >> testCheckZombieStateWithOnExitApi [
 	
 ]
 
-{ #category : #'tests - child status' }
+{ #category : 'tests - child status' }
 OSSUnixSubprocessTest >> testCheckZombieStateWithWaitChild [
 	| command oldZombies | 
 	oldZombies := self numberOfZombiesProcesses.
@@ -362,7 +363,7 @@ OSSUnixSubprocessTest >> testCheckZombieStateWithWaitChild [
 	
 ]
 
-{ #category : #'tests - wait' }
+{ #category : 'tests - wait' }
 OSSUnixSubprocessTest >> testCommandReturningDifferentThanZero [
 	| command | 
 	
@@ -377,7 +378,7 @@ OSSUnixSubprocessTest >> testCommandReturningDifferentThanZero [
 	self deny: (command exitStatusInterpreter exitStatus = 0)
 ]
 
-{ #category : #'tests - streams' }
+{ #category : 'tests - streams' }
 OSSUnixSubprocessTest >> testCreateMissingStandardStreamsDisabled [
 	| command | 
 	
@@ -391,7 +392,7 @@ OSSUnixSubprocessTest >> testCreateMissingStandardStreamsDisabled [
 	
 ]
 
-{ #category : #'tests - streams' }
+{ #category : 'tests - streams' }
 OSSUnixSubprocessTest >> testCreateMissingStandardStreamsEnabled [
 	| command streamsInfo | 
 	streamsInfo := self getStreamsInfoForRunningTest.
@@ -409,7 +410,7 @@ OSSUnixSubprocessTest >> testCreateMissingStandardStreamsEnabled [
 	
 ]
 
-{ #category : #'tests - shell' }
+{ #category : 'tests - shell' }
 OSSUnixSubprocessTest >> testCustomShellWithStdout [
 
 	self newCommand
@@ -422,7 +423,7 @@ OSSUnixSubprocessTest >> testCustomShellWithStdout [
 
 ]
 
-{ #category : #'tests - streams' }
+{ #category : 'tests - streams' }
 OSSUnixSubprocessTest >> testCustomStdoutStream [
 	| customStream streamsInfo | 
 	streamsInfo := self getStreamsInfoForRunningTest.
@@ -442,7 +443,7 @@ OSSUnixSubprocessTest >> testCustomStdoutStream [
 
 ]
 
-{ #category : #'tests - child status' }
+{ #category : 'tests - child status' }
 OSSUnixSubprocessTest >> testGetChildPid [
 	| command | 
 	
@@ -454,7 +455,7 @@ OSSUnixSubprocessTest >> testGetChildPid [
 	command waitForExit. 
 ]
 
-{ #category : #'tests - child status' }
+{ #category : 'tests - child status' }
 OSSUnixSubprocessTest >> testGetChildStatusAfterFailingCommand [
 	| command oldZombies | 
 	oldZombies := self numberOfZombiesProcesses.
@@ -472,7 +473,7 @@ OSSUnixSubprocessTest >> testGetChildStatusAfterFailingCommand [
 	self assert: self numberOfZombiesProcesses equals: oldZombies.
 ]
 
-{ #category : #'tests - child status' }
+{ #category : 'tests - child status' }
 OSSUnixSubprocessTest >> testGetChildStatusAfterFinishesMultipleTimes [
 	| command oldZombies | 
 	oldZombies := self numberOfZombiesProcesses.
@@ -495,7 +496,7 @@ OSSUnixSubprocessTest >> testGetChildStatusAfterFinishesMultipleTimes [
 	self assert: self numberOfZombiesProcesses equals: oldZombies.
 ]
 
-{ #category : #'tests - child status' }
+{ #category : 'tests - child status' }
 OSSUnixSubprocessTest >> testGetChildStatusAfterFinishesSuccess [
 	| command oldZombies | 
 	oldZombies := self numberOfZombiesProcesses.
@@ -513,7 +514,7 @@ OSSUnixSubprocessTest >> testGetChildStatusAfterFinishesSuccess [
 	self assert: self numberOfZombiesProcesses equals: oldZombies.
 ]
 
-{ #category : #'tests - child status' }
+{ #category : 'tests - child status' }
 OSSUnixSubprocessTest >> testGetChildStatusBeforeAndAfterFinishing [
 	| command oldZombies | 
 	oldZombies := self numberOfZombiesProcesses.
@@ -535,7 +536,7 @@ OSSUnixSubprocessTest >> testGetChildStatusBeforeAndAfterFinishing [
 	
 ]
 
-{ #category : #'tests - env' }
+{ #category : 'tests - env' }
 OSSUnixSubprocessTest >> testInheritVarFromEnv [
 	| command | 
 	command := self newCommand
@@ -546,7 +547,7 @@ OSSUnixSubprocessTest >> testInheritVarFromEnv [
 	'/tmp/testReadUserDefinedEnvVar' asFileReference ensureDelete. 
 ]
 
-{ #category : #'tests - basic' }
+{ #category : 'tests - basic' }
 OSSUnixSubprocessTest >> testNoneExistingCommand [
 	| command stdout stderr | 
 	
@@ -568,7 +569,7 @@ OSSUnixSubprocessTest >> testNoneExistingCommand [
 	command closeAndCleanStreams.
 ]
 
-{ #category : #'tests - streams' }
+{ #category : 'tests - streams' }
 OSSUnixSubprocessTest >> testReadingFromStdoutAfterCommandFinishesDoesNotBlocksVM [
 	| command streamsInfo | 
 	
@@ -596,7 +597,7 @@ OSSUnixSubprocessTest >> testReadingFromStdoutAfterCommandFinishesDoesNotBlocksV
 	
 ]
 
-{ #category : #'tests - wait' }
+{ #category : 'tests - wait' }
 OSSUnixSubprocessTest >> testRunAndWaitPollingEveryRetrievingStreamsOnExitDo [
 	self newCommand 
 		command: '/bin/ls';
@@ -611,7 +612,7 @@ OSSUnixSubprocessTest >> testRunAndWaitPollingEveryRetrievingStreamsOnExitDo [
 
 ]
 
-{ #category : #'tests - env' }
+{ #category : 'tests - env' }
 OSSUnixSubprocessTest >> testSetAndReadCustomVariable [
 	self newCommand 
 		shellCommand: 'echo ${WHATEVER}';
@@ -623,7 +624,7 @@ OSSUnixSubprocessTest >> testSetAndReadCustomVariable [
 
 ]
 
-{ #category : #'tests - env' }
+{ #category : 'tests - env' }
 OSSUnixSubprocessTest >> testSetAndReadCustomVariableOutsideShell [
 	self newCommand 
 		command: 'printenv';
@@ -636,7 +637,7 @@ OSSUnixSubprocessTest >> testSetAndReadCustomVariableOutsideShell [
 
 ]
 
-{ #category : #'tests - env' }
+{ #category : 'tests - env' }
 OSSUnixSubprocessTest >> testSetCustomVariableOutsideShellAndPassedToCommand [
 	" This test demonstrates that we do not expand variables automatically. So if you don't use the shell, or any other special command that
 	will search for special variables (like git searching $GIT_EDITOR), these will not be resolved. 
@@ -654,7 +655,7 @@ OSSUnixSubprocessTest >> testSetCustomVariableOutsideShellAndPassedToCommand [
 
 ]
 
-{ #category : #'tests - wait' }
+{ #category : 'tests - wait' }
 OSSUnixSubprocessTest >> testShellCommandReturningDifferentThanZero [
 	| command | 
 	
@@ -664,7 +665,7 @@ OSSUnixSubprocessTest >> testShellCommandReturningDifferentThanZero [
 	self assert: command exitStatusInterpreter exitStatus equals: 2. 
 ]
 
-{ #category : #'tests - shell' }
+{ #category : 'tests - shell' }
 OSSUnixSubprocessTest >> testShellCommandWithPipingStdout [
 
 	self newCommand
@@ -677,7 +678,7 @@ OSSUnixSubprocessTest >> testShellCommandWithPipingStdout [
 
 ]
 
-{ #category : #'tests - shell' }
+{ #category : 'tests - shell' }
 OSSUnixSubprocessTest >> testShellCommandWithStreamRedirects [
 	| stdOutContents | 
 
@@ -696,7 +697,7 @@ OSSUnixSubprocessTest >> testShellCommandWithStreamRedirects [
 	
 ]
 
-{ #category : #'tests - signals' }
+{ #category : 'tests - signals' }
 OSSUnixSubprocessTest >> testSigTerm [
 
 	| process exited streamsInfo |
@@ -738,7 +739,7 @@ OSSUnixSubprocessTest >> testSigTerm [
 
 ]
 
-{ #category : #'tests - signals' }
+{ #category : 'tests - signals' }
 OSSUnixSubprocessTest >> testSigTermInsideLoop [
 
 	| process exited streamsInfo |
@@ -771,7 +772,7 @@ OSSUnixSubprocessTest >> testSigTermInsideLoop [
 
 ]
 
-{ #category : #'tests - wait' }
+{ #category : 'tests - wait' }
 OSSUnixSubprocessTest >> testStopWaitingWithPolling [
 	| process counter oldZombies |
 	process := self newCommand.
@@ -808,7 +809,7 @@ OSSUnixSubprocessTest >> testStopWaitingWithPolling [
 	
 ]
 
-{ #category : #'tests - wait' }
+{ #category : 'tests - wait' }
 OSSUnixSubprocessTest >> testStopWaitingWithSigchld [
 	| process counter oldZombies |
 	process := self newCommand.
@@ -843,7 +844,7 @@ OSSUnixSubprocessTest >> testStopWaitingWithSigchld [
 	
 ]
 
-{ #category : #'tests - wait' }
+{ #category : 'tests - wait' }
 OSSUnixSubprocessTest >> testWaitForExit [
 	| command | 
 	
@@ -857,7 +858,7 @@ OSSUnixSubprocessTest >> testWaitForExit [
 	self assert: command exitStatusInterpreter exitStatus equals: 0. 
 ]
 
-{ #category : #'tests - wait' }
+{ #category : 'tests - wait' }
 OSSUnixSubprocessTest >> testWaitForExitPolling [
 	| command | 
 	
@@ -871,7 +872,7 @@ OSSUnixSubprocessTest >> testWaitForExitPolling [
 	self assert: command exitStatusInterpreter exitStatus equals: 0. 
 ]
 
-{ #category : #'tests - wait' }
+{ #category : 'tests - wait' }
 OSSUnixSubprocessTest >> testWaitForExitPollingEvery [
 	| command | 
 	
@@ -885,7 +886,7 @@ OSSUnixSubprocessTest >> testWaitForExitPollingEvery [
 	self assert: command exitStatusInterpreter exitStatus equals: 0. 
 ]
 
-{ #category : #'tests - high API' }
+{ #category : 'tests - high API' }
 OSSUnixSubprocessTest >> testWaitForExitPollingEveryDoing [
 	| streamsInfo totalRead |
 	totalRead := String new writeStream.
@@ -910,7 +911,7 @@ OSSUnixSubprocessTest >> testWaitForExitPollingEveryDoing [
 	
 ]
 
-{ #category : #'tests - wait' }
+{ #category : 'tests - wait' }
 OSSUnixSubprocessTest >> testWaitForExitWithTimeoutWillFailIfProcessDoesNotFinish [
 	| command | 
 	
@@ -926,7 +927,7 @@ OSSUnixSubprocessTest >> testWaitForExitWithTimeoutWillFailIfProcessDoesNotFinis
 	self assert: command isRunning.
 ]
 
-{ #category : #'tests - wait' }
+{ #category : 'tests - wait' }
 OSSUnixSubprocessTest >> testWaitForExitWithTimeoutWillNotTimeoutIfProcessFinishes [
 	| command | 
 	
@@ -941,7 +942,7 @@ OSSUnixSubprocessTest >> testWaitForExitWithTimeoutWillNotTimeoutIfProcessFinish
 	self assert: command exitStatusInterpreter exitStatus equals: 0. 
 ]
 
-{ #category : #'tests - wait' }
+{ #category : 'tests - wait' }
 OSSUnixSubprocessTest >> testWaitpidIsNoneBocking [
 	| command childStatus | 
 	
@@ -957,7 +958,7 @@ OSSUnixSubprocessTest >> testWaitpidIsNoneBocking [
 	command waitForExit.
 ]
 
-{ #category : #'tests - pwd' }
+{ #category : 'tests - pwd' }
 OSSUnixSubprocessTest >> testWorkingDirectory [
 	| oldWorkingDirectory | 
 
@@ -979,10 +980,10 @@ OSSUnixSubprocessTest >> testWorkingDirectory [
 
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 OSSUnixSubprocessTest >> withNonAsciiDirectoryDo: aBlock [ 
 	| directory |
-	directory := FileLocator temp / (self class name , '-éoï-' , UUIDGenerator next asString).
+	directory := FileLocator temp / (self class name , '-éoï-' , UUID new asString).
 	directory ensureCreateDirectory.
 	[ aBlock cull: directory asFileReference ]
 	ensure: [ directory ensureDeleteAll ]

--- a/repository/OSSubprocess-Tests-Unit/OSSVMProcessTest.class.st
+++ b/repository/OSSubprocess-Tests-Unit/OSSVMProcessTest.class.st
@@ -1,17 +1,18 @@
 Class {
-	#name : #OSSVMProcessTest,
-	#superclass : #OSSAbstractUnixSubprocessTest,
-	#category : 'OSSubprocess-Tests-Unit'
+	#name : 'OSSVMProcessTest',
+	#superclass : 'OSSAbstractUnixSubprocessTest',
+	#category : 'OSSubprocess-Tests-Unit',
+	#package : 'OSSubprocess-Tests-Unit'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OSSVMProcessTest >> runCaseManaged [
 	"testChangeDirWithNonAsciiCharacters test has to download the unicode table that can take some time.
 	Disable test timeout."
 	^ self runCase
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 OSSVMProcessTest >> testChangeDir [
 	| oldDir | 
 	oldDir := self systemAccessor getcwd.
@@ -26,7 +27,7 @@ OSSVMProcessTest >> testChangeDir [
 				
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 OSSVMProcessTest >> testChangeDirWithNonAsciiCharacters [
 	| oldDir newDir duringSystemCwd | 
 	oldDir := self systemAccessor getcwd.
@@ -45,7 +46,7 @@ OSSVMProcessTest >> testChangeDirWithNonAsciiCharacters [
 	newDir ensureDelete.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 OSSVMProcessTest >> testChangeDirWithNonExistingDir [
 	| oldDir |
 	oldDir := self systemAccessor getcwd.
@@ -58,7 +59,7 @@ OSSVMProcessTest >> testChangeDirWithNonExistingDir [
 	self assert: self systemAccessor getcwd equals: oldDir
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 OSSVMProcessTest >> testChildrenCollectionsWithOneProcessBeforeAndAfter [
 	| command | 
 	OSSVMProcess vmProcess initializeAllMyChildren. 
@@ -89,7 +90,7 @@ OSSVMProcessTest >> testChildrenCollectionsWithOneProcessBeforeAndAfter [
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 OSSVMProcessTest >> testInitializeChildren [
 
 	OSSVMProcess vmProcess initializeAllMyChildren.
@@ -104,7 +105,7 @@ OSSVMProcessTest >> testInitializeChildren [
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 OSSVMProcessTest >> testPruneExitedChildrenAfter [
 	| command | 
 	OSSVMProcess vmProcess initializeAllMyChildren. 

--- a/repository/OSSubprocess-Tests-Unit/package.st
+++ b/repository/OSSubprocess-Tests-Unit/package.st
@@ -1,1 +1,1 @@
-Package { #name : #'OSSubprocess-Tests-Unit' }
+Package { #name : 'OSSubprocess-Tests-Unit' }

--- a/repository/OSSubprocess/OSSUnixSubprocess.class.st
+++ b/repository/OSSubprocess/OSSUnixSubprocess.class.st
@@ -323,7 +323,7 @@ OSSUnixSubprocess >> createMissingStandardStreams: aBoolean [
 
 { #category : 'accessing' }
 OSSUnixSubprocess >> defaultEncoding [ 
-	^ OSEnvironment current defaultEncoding 
+	^ OSPlatform current defaultEncoding 
 ]
 
 { #category : 'env building' }


### PR DESCRIPTION
Many tests failed, and the first code example in the README did not work in Pharo 14.  These changes fix both.

Summary of changes:
+ `OSSUnixSubprocess >> #defaultEncoding`: Use `OSPlatform` instead of `OSEnvironment` to retrieve the default encoding.
+ `OSSUnixSubprocessTest >> #withNonAsciiDirectoryDo:`: Use `UUID class >> #new` instead of `UUIDGenerator class >> #next`, as the latter does not exist anymore.
